### PR TITLE
Refactor :  게시글 하나 조회시 N+1 문제 해결 및 반환타입 요구사항 수정 완료

### DIFF
--- a/src/main/java/com/backend/moamoa/domain/post/controller/PostController.java
+++ b/src/main/java/com/backend/moamoa/domain/post/controller/PostController.java
@@ -42,7 +42,7 @@ public class PostController {
         return postService.getRecentPost(pageable, categoryName);
     }
 
-    @ApiOperation(value = "게시글 생성", notes = "Request Body 값을 받아와서 글을 생성하는 API",
+    @ApiOperation(value = "게시글 생성", notes = "Form Data 값을 받아와서 글을 생성하는 API",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "해당 게시글이 정상적으로 생성된 경우"),

--- a/src/main/java/com/backend/moamoa/domain/post/dto/response/CommentsChildrenResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/post/dto/response/CommentsChildrenResponse.java
@@ -21,6 +21,8 @@ public class CommentsChildrenResponse {
 
     private String username;
 
+    private boolean myComment;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createDate;
 
@@ -28,11 +30,12 @@ public class CommentsChildrenResponse {
     private LocalDateTime updateDate;
 
     @QueryProjection
-    public CommentsChildrenResponse(Long parentId, Long commentId, String content, String username, LocalDateTime createDate, LocalDateTime updateDate) {
+    public CommentsChildrenResponse(Long parentId, Long commentId, String content, String username, boolean myComment, LocalDateTime createDate, LocalDateTime updateDate) {
         this.parentId = parentId;
         this.commentId = commentId;
         this.content = content;
         this.username = username;
+        this.myComment = myComment;
         this.createDate = createDate;
         this.updateDate = updateDate;
     }

--- a/src/main/java/com/backend/moamoa/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/post/dto/response/PostCreateResponse.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -21,5 +22,6 @@ public class PostCreateResponse {
     private String message;
 
     @ApiModelProperty(value = "이미지 경로")
-    private List<String> imageUrl;
+    private List<String> imageUrl = new ArrayList<>();
 }
+

--- a/src/main/java/com/backend/moamoa/domain/post/dto/response/PostOneCommentResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/post/dto/response/PostOneCommentResponse.java
@@ -23,6 +23,8 @@ public class PostOneCommentResponse {
 
     private String username;
 
+    private boolean myComment;
+
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime createDate;
 
@@ -32,13 +34,15 @@ public class PostOneCommentResponse {
     private List<CommentsChildrenResponse> children = new ArrayList<>();
 
     @QueryProjection
-    public PostOneCommentResponse(Long parentId, Long commentId, String content, String username, LocalDateTime createDate, LocalDateTime updateDate) {
+    public PostOneCommentResponse(Long parentId, Long commentId, String content, String username, boolean myComment, LocalDateTime createDate, LocalDateTime updateDate) {
         this.parentId = parentId;
         this.commentId = commentId;
         this.content = content;
         this.username = username;
+        this.myComment = myComment;
         this.createDate = createDate;
         this.updateDate = updateDate;
     }
+
 
 }

--- a/src/main/java/com/backend/moamoa/domain/post/dto/response/PostOneResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/post/dto/response/PostOneResponse.java
@@ -51,10 +51,20 @@ public class PostOneResponse {
     @ApiModelProperty(value = "해당 게시글의 생성 회원 이름")
     private String username;
 
+    @ApiModelProperty(value = "해당 게시글의 유저 본인 확인")
+    private boolean myPost;
+
+    @ApiModelProperty(value = "해당 게시글의 좋아요 본인 확인")
+    private boolean myLike;
+
+    @ApiModelProperty(value = "해당 게시글의 스크랩 본인 확인")
+    private boolean myScrap;
+
+    @ApiModelProperty(value = "해당 게시글의 댓글")
     private List<PostOneCommentResponse> comments = new ArrayList<>();
 
     @QueryProjection
-    public PostOneResponse(Long postId, String title, String content, int scrapCount, int commentCount, int likeCount, LocalDateTime createDate, LocalDateTime updateDate, Integer viewCount, String username) {
+    public PostOneResponse(Long postId, String title, String content, int scrapCount, int commentCount, int likeCount, LocalDateTime createDate, LocalDateTime updateDate, Integer viewCount, String username, boolean myPost, boolean myLike, boolean myScrap) {
         this.postId = postId;
         this.title = title;
         this.content = content;
@@ -65,6 +75,9 @@ public class PostOneResponse {
         this.updateDate = updateDate;
         this.viewCount = viewCount;
         this.username = username;
+        this.myPost = myPost;
+        this.myLike = myLike;
+        this.myScrap = myScrap;
     }
 
 }

--- a/src/main/java/com/backend/moamoa/domain/post/repository/comment/CommentCustomRepository.java
+++ b/src/main/java/com/backend/moamoa/domain/post/repository/comment/CommentCustomRepository.java
@@ -1,16 +1,11 @@
 package com.backend.moamoa.domain.post.repository.comment;
 
-import com.backend.moamoa.domain.post.dto.response.CommentsChildrenResponse;
-import com.backend.moamoa.domain.post.dto.response.PostOneCommentResponse;
 import com.backend.moamoa.domain.post.entity.Comment;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface CommentCustomRepository {
 
     Optional<Comment> findWithPostAndMemberById(Long userId, Long commentId);
-
-    List<CommentsChildrenResponse> findPostComments(Long postId, Long commentId);
 
 }

--- a/src/main/java/com/backend/moamoa/domain/post/repository/comment/CommentRepositoryImpl.java
+++ b/src/main/java/com/backend/moamoa/domain/post/repository/comment/CommentRepositoryImpl.java
@@ -1,13 +1,9 @@
 package com.backend.moamoa.domain.post.repository.comment;
 
-import com.backend.moamoa.domain.post.dto.response.CommentsChildrenResponse;
-import com.backend.moamoa.domain.post.dto.response.PostOneCommentResponse;
-import com.backend.moamoa.domain.post.dto.response.QCommentsChildrenResponse;
 import com.backend.moamoa.domain.post.entity.Comment;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
-import java.util.List;
 import java.util.Optional;
 
 import static com.backend.moamoa.domain.post.entity.QComment.comment;
@@ -29,22 +25,4 @@ public class CommentRepositoryImpl implements CommentCustomRepository {
                 .fetchOne());
     }
 
-    @Override
-    public List<CommentsChildrenResponse> findPostComments(Long postId, Long commentId) {
-
-        return queryFactory.select(new QCommentsChildrenResponse(
-                        comment.parent.id,
-                        comment.id,
-                        comment.content,
-                        user.nickname,
-                        comment.timeEntity.createdDate,
-                        comment.timeEntity.updatedDate))
-                .from(comment)
-                .innerJoin(comment.parent)
-                .innerJoin(comment.post, post)
-                .innerJoin(post.user, user)
-                .where(post.id.eq(postId).and(comment.parent.id.eq(commentId)))
-                .orderBy(comment.id.asc())
-                .fetch();
-    }
 }

--- a/src/main/java/com/backend/moamoa/domain/post/repository/post/PostCustomRepository.java
+++ b/src/main/java/com/backend/moamoa/domain/post/repository/post/PostCustomRepository.java
@@ -10,10 +10,10 @@ import java.util.Optional;
 
 public interface PostCustomRepository {
 
-    Optional<PostOneResponse> findOnePostById(Long postId);
+    Optional<PostOneResponse> findOnePostById(Long postId, Long userId);
 
     Page<RecentPostResponse> findRecentPosts(Pageable pageable, String categoryName);
 
-    Optional<Post> findByIdAndUser(Long postId, Long id);
+    Optional<Post> findByIdAndUser(Long postId, Long userId);
 
 }

--- a/src/main/java/com/backend/moamoa/domain/post/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/moamoa/domain/post/repository/post/PostRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.backend.moamoa.domain.post.repository.post;
 
 import com.backend.moamoa.domain.post.dto.response.*;
 import com.backend.moamoa.domain.post.entity.Post;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -11,10 +12,13 @@ import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.backend.moamoa.domain.post.entity.QComment.comment;
 import static com.backend.moamoa.domain.post.entity.QPost.post;
 import static com.backend.moamoa.domain.post.entity.QPostCategory.postCategory;
+import static com.backend.moamoa.domain.post.entity.QPostLike.postLike;
+import static com.backend.moamoa.domain.post.entity.QScrap.scrap;
 import static com.backend.moamoa.domain.user.entity.QUser.user;
 
 @RequiredArgsConstructor
@@ -23,7 +27,7 @@ public class PostRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Optional<PostOneResponse> findOnePostById(Long postId) {
+    public Optional<PostOneResponse> findOnePostById(Long postId, Long userId) {
         queryFactory.update(post)
                 .set(post.viewCount, post.viewCount.add(1))
                 .where(post.id.eq(postId))
@@ -40,7 +44,19 @@ public class PostRepositoryImpl implements PostCustomRepository {
                         post.timeEntity.createdDate,
                         post.timeEntity.updatedDate,
                         post.viewCount,
-                        user.nickname))
+                        user.nickname,
+                        JPAExpressions
+                                .selectFrom(post)
+                                .where(user.id.eq(userId))
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(postLike)
+                                .where(postLike.post.eq(post).and(user.id.eq(userId)))
+                                .exists(),
+                        JPAExpressions
+                                .selectFrom(scrap)
+                                .where(scrap.post.eq(post).and(user.id.eq(userId)))
+                                .exists()))
                 .from(post)
                 .innerJoin(post.user, user)
                 .where(post.id.eq(postId))
@@ -56,14 +72,44 @@ public class PostRepositoryImpl implements PostCustomRepository {
                         comment.id,
                         comment.content,
                         user.nickname,
+                        JPAExpressions
+                                .selectFrom(comment)
+                                .where(user.id.eq(userId))
+                                .exists(),
                         comment.timeEntity.createdDate,
                         comment.timeEntity.updatedDate))
                 .from(comment)
                 .innerJoin(comment.post, post)
-                .innerJoin(post.user, user)
-                .where(post.id.eq(postId).and(comment.parent.isNull()))
+                .innerJoin(comment.user, user)
+                .where(post.id.eq(postId).and(comment.parent.id.isNull()))
                 .orderBy(comment.id.asc())
                 .fetch();
+
+        List<CommentsChildrenResponse> childComments = queryFactory
+                .select(new QCommentsChildrenResponse(
+                        comment.parent.id,
+                        comment.id,
+                        comment.content,
+                        user.nickname,
+                        JPAExpressions
+                                .selectFrom(comment)
+                                .where(user.id.eq(userId))
+                                .exists(),
+                        comment.timeEntity.createdDate,
+                        comment.timeEntity.updatedDate
+                ))
+                .from(comment)
+                .innerJoin(comment.post, post)
+                .innerJoin(comment.user, user)
+                .where(post.id.eq(postId).and(comment.parent.id.isNotNull()))
+                .fetch();
+
+        comments.stream()
+                .forEach(parent -> {
+                    parent.setChildren(childComments.stream()
+                            .filter(child -> child.getParentId().equals(parent.getCommentId()))
+                            .collect(Collectors.toList()));
+                });
 
         response.get().setComments(comments);
 
@@ -99,15 +145,14 @@ public class PostRepositoryImpl implements PostCustomRepository {
                 .fetchCount();
 
         return PageableExecutionUtils.getPage(content, pageable, () -> countQuery);
-
     }
 
     @Override
-    public Optional<Post> findByIdAndUser(Long postId, Long id) {
+    public Optional<Post> findByIdAndUser(Long postId, Long userId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(post)
                 .innerJoin(post.user, user)
-                .where(post.id.eq(postId).and(user.id.eq(id)))
+                .where(post.id.eq(postId).and(user.id.eq(userId)))
                 .fetchOne());
     }
 }

--- a/src/main/java/com/backend/moamoa/domain/post/service/CommentService.java
+++ b/src/main/java/com/backend/moamoa/domain/post/service/CommentService.java
@@ -30,7 +30,7 @@ public class CommentService {
 
     @Transactional
     public CommentResponse createComment(CommentRequest commentRequest) {
-        User user = userRepository.findById(1L).get();
+        User user = userRepository.findById(2L).get();
         Post post = postRepository.findById(commentRequest.getPostId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
         Long parentId = commentRequest.getParentId();

--- a/src/main/java/com/backend/moamoa/global/exception/CustomException.java
+++ b/src/main/java/com/backend/moamoa/global/exception/CustomException.java
@@ -1,7 +1,6 @@
 package com.backend.moamoa.global.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
 public class CustomException extends RuntimeException{

--- a/src/main/java/com/backend/moamoa/global/exception/ErrorResponse.java
+++ b/src/main/java/com/backend/moamoa/global/exception/ErrorResponse.java
@@ -1,18 +1,19 @@
 package com.backend.moamoa.global.exception;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 
 @Getter
 @Builder
 @RequiredArgsConstructor
 public class ErrorResponse {
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private final LocalDateTime time = LocalDateTime.now();
     private final int status;
     private final String error;


### PR DESCRIPTION
## 변경 사항

-  저번 주 회의에서 은비님이 말씀해주신 게시글 수정 요구사항 다 수정했습니다. (게시글, 댓글, 대댓글, 좋아요, 스크랩)에 대한 `validate`
- 게시글 하나 조회시 발생했던 `N+1` 문제 해결 
- `ErrorResponse`에 `@JonFormat` 추가

