### PR TITLE
Refactor : 게시글 단건 조회시 이미지 경로 반환 + user를 검증하는 부분 리팩토링

### DIFF
--- a/src/main/java/com/backend/moamoa/domain/asset/service/AssetService.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/service/AssetService.java
@@ -15,9 +15,9 @@ import com.backend.moamoa.domain.asset.repository.BudgetRepository;
 import com.backend.moamoa.domain.asset.repository.ExpenditureRatioRepository;
 import com.backend.moamoa.domain.asset.repository.RevenueExpenditureRepository;
 import com.backend.moamoa.domain.user.entity.User;
-import com.backend.moamoa.domain.user.repository.UserRepository;
 import com.backend.moamoa.global.exception.CustomException;
 import com.backend.moamoa.global.exception.ErrorCode;
+import com.backend.moamoa.global.utils.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,10 +25,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,27 +35,27 @@ public class AssetService {
     private static final String TYPE_REVENUE = "REVENUE";
     private static final String TYPE_EXPENDITURE = "EXPENDITURE";
 
-    private final UserRepository userRepository;
     private final AssetCategoryRepository assetCategoryRepository;
     private final BudgetRepository budgetRepository;
     private final ExpenditureRatioRepository expenditureRatioRepository;
     private final RevenueExpenditureRepository revenueExpenditureRepository;
+    private final UserUtil userUtil;
 
     @Transactional
     public Long addCategory(AssetCategoryRequest request) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         return assetCategoryRepository.save(AssetCategory.createCategory(request.getCategoryType(), request.getCategoryName(), user)).getId();
     }
 
     @Transactional
     public Long addBudget(BudgetRequest request) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         return budgetRepository.save(Budget.createBudget(request.getBudgetAmount(), user)).getId();
     }
 
     @Transactional
     public Long addExpenditure(ExpenditureRequest request) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         if (request.getFixed() + request.getVariable() != 100) {
             throw new CustomException(ErrorCode.BAD_REQUEST_EXPENDITURE);
         }
@@ -66,14 +63,14 @@ public class AssetService {
     }
 
     public List<String> getCategories(String categoryType) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
 
         return assetCategoryRepository.findByAssetCategoryTypeAndUserId(categoryType, user.getId());
     }
 
     @Transactional
     public void deleteCategoryName(Long categoryId) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         AssetCategory category = assetCategoryRepository.findByIdAndUserId(categoryId, user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ASSET_CATEGORY));
 
@@ -82,7 +79,7 @@ public class AssetService {
 
     @Transactional
     public Long addRevenueExpenditure(CreateRevenueExpenditureRequest request) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
 
         return revenueExpenditureRepository.save(RevenueExpenditure.builder()
                 .revenueExpenditureType(request.getRevenueExpenditureType())
@@ -96,7 +93,7 @@ public class AssetService {
     }
 
     public RevenueExpenditureSumResponse findRevenueExpenditureByMonth(String month, Pageable pageable) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
 
         Page<RevenueExpenditureResponse> revenueExpenditure = revenueExpenditureRepository.findRevenueAndExpenditureByMonth(LocalDate.parse(month + "-01"), pageable, user.getId());
 

--- a/src/main/java/com/backend/moamoa/domain/post/dto/response/PostOneResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/post/dto/response/PostOneResponse.java
@@ -60,6 +60,9 @@ public class PostOneResponse {
     @ApiModelProperty(value = "해당 게시글의 스크랩 본인 확인")
     private boolean myScrap;
 
+    @ApiModelProperty(value = "해당 게시글에 저장된 이미지 경로")
+    private List<String> imageUrl = new ArrayList<>();
+
     @ApiModelProperty(value = "해당 게시글의 댓글")
     private List<PostOneCommentResponse> comments = new ArrayList<>();
 

--- a/src/main/java/com/backend/moamoa/domain/post/repository/post/PostRepositoryImpl.java
+++ b/src/main/java/com/backend/moamoa/domain/post/repository/post/PostRepositoryImpl.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import static com.backend.moamoa.domain.post.entity.QComment.comment;
 import static com.backend.moamoa.domain.post.entity.QPost.post;
 import static com.backend.moamoa.domain.post.entity.QPostCategory.postCategory;
+import static com.backend.moamoa.domain.post.entity.QPostImage.postImage;
 import static com.backend.moamoa.domain.post.entity.QPostLike.postLike;
 import static com.backend.moamoa.domain.post.entity.QScrap.scrap;
 import static com.backend.moamoa.domain.user.entity.QUser.user;
@@ -65,6 +66,15 @@ public class PostRepositoryImpl implements PostCustomRepository {
         if (response.isEmpty()) {
             return Optional.empty();
         }
+
+        List<String> postImages = queryFactory
+                .select(postImage.imageUrl)
+                .from(postImage)
+                .innerJoin(postImage.post, post)
+                .where(post.id.eq(postId))
+                .fetch();
+
+        response.get().setImageUrl(postImages);
 
         List<PostOneCommentResponse> comments = queryFactory
                 .select(new QPostOneCommentResponse(

--- a/src/main/java/com/backend/moamoa/domain/post/service/CommentService.java
+++ b/src/main/java/com/backend/moamoa/domain/post/service/CommentService.java
@@ -10,9 +10,9 @@ import com.backend.moamoa.domain.post.entity.Post;
 import com.backend.moamoa.domain.post.repository.comment.CommentRepository;
 import com.backend.moamoa.domain.post.repository.post.PostRepository;
 import com.backend.moamoa.domain.user.entity.User;
-import com.backend.moamoa.domain.user.repository.UserRepository;
 import com.backend.moamoa.global.exception.CustomException;
 import com.backend.moamoa.global.exception.ErrorCode;
+import com.backend.moamoa.global.utils.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,13 +24,13 @@ import java.util.Objects;
 @Transactional(readOnly = true)
 public class CommentService {
 
-    private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final UserUtil userUtil;
 
     @Transactional
     public CommentResponse createComment(CommentRequest commentRequest) {
-        User user = userRepository.findById(2L).get();
+        User user = userUtil.findCurrentUser();
         Post post = postRepository.findById(commentRequest.getPostId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
         Long parentId = commentRequest.getParentId();
@@ -55,7 +55,7 @@ public class CommentService {
 
     @Transactional
     public CommentDeleteResponse deleteComment(Long commentId) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
 
         commentRepository.delete(getComment(commentId, user));
 
@@ -64,7 +64,7 @@ public class CommentService {
 
     @Transactional
     public CommentUpdateResponse updateComment(CommentUpdateRequest request) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         Comment comment = getComment(request.getCommentId(), user);
         comment.updateContent(request.getContent());
 

--- a/src/main/java/com/backend/moamoa/domain/post/service/PostService.java
+++ b/src/main/java/com/backend/moamoa/domain/post/service/PostService.java
@@ -6,10 +6,10 @@ import com.backend.moamoa.domain.post.dto.response.*;
 import com.backend.moamoa.domain.post.entity.*;
 import com.backend.moamoa.domain.post.repository.post.*;
 import com.backend.moamoa.domain.user.entity.User;
-import com.backend.moamoa.domain.user.repository.UserRepository;
 import com.backend.moamoa.global.exception.CustomException;
 import com.backend.moamoa.global.exception.ErrorCode;
 import com.backend.moamoa.global.s3.S3Uploader;
+import com.backend.moamoa.global.utils.UserUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -30,19 +30,19 @@ import java.util.stream.Collectors;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
     private final PostCategoryRepository postCategoryRepository;
     private final PostLikeRepository postLikeRepository;
     private final ScrapRepository scrapRepository;
     private final S3Uploader s3Uploader;
     private final PostImageRepository postImageRepository;
+    private final UserUtil userUtil;
 
 
     @Transactional
     public PostCreateResponse createPost(PostRequest postRequest) {
         PostCategory postCategory = postCategoryRepository.findByCategoryName(postRequest.getCategoryName())
                 .orElseGet(() -> PostCategory.createCategory(postRequest.getCategoryName()));
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         Post post = postRepository.save(Post.createPost(postRequest.getTitle(), postRequest.getContent(), user, postCategory));
         List<String> postImages = uploadPostImages(postRequest, post);
 
@@ -73,7 +73,7 @@ public class PostService {
 
     @Transactional
     public PostUpdateResponse updatePost(PostUpdateRequest request) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         Post post = postRepository.findByIdAndUser(request.getPostId(), user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
 
@@ -122,7 +122,7 @@ public class PostService {
 
     @Transactional
     public PostResponse deletePost(Long postId) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         Post post = postRepository.findByIdAndUser(postId, user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
 
@@ -136,7 +136,7 @@ public class PostService {
      */
     @Transactional
     public PostOneResponse getOnePost(Long postId) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         return postRepository.findOnePostById(postId, user.getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_POST));
     }
@@ -153,7 +153,7 @@ public class PostService {
 
     @Transactional
     public LikeResponse likePost(Long postId) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         Post post = getPost(postId);
         Optional<PostLike> postLike = postLikeRepository.findByUserAndPost(user, post);
 
@@ -167,7 +167,7 @@ public class PostService {
 
     @Transactional
     public ScrapResponse scrapPost(Long postId) {
-        User user = userRepository.findById(1L).get();
+        User user = userUtil.findCurrentUser();
         Post post = getPost(postId);
 
         Optional<Scrap> scrap = scrapRepository.findByUserAndPost(user, post);

--- a/src/main/java/com/backend/moamoa/domain/user/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/backend/moamoa/domain/user/oauth/service/CustomOAuth2UserService.java
@@ -7,6 +7,7 @@ import com.backend.moamoa.domain.user.oauth.info.OAuth2UserInfo;
 import com.backend.moamoa.domain.user.oauth.info.OAuth2UserInfoFactory;
 import com.backend.moamoa.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -20,6 +21,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     private final UserRepository userRepository;
@@ -42,6 +44,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         ProviderType providerType = ProviderType.valueOf(userRequest.getClientRegistration().getRegistrationId().toUpperCase());
 
         OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, user.getAttributes());
+        log.info("CustomOauth2USer!!");
         Optional<User> savedUser = userRepository.findByUserId(userInfo.getId());
 
         if (savedUser.isPresent()) {

--- a/src/main/java/com/backend/moamoa/domain/user/oauth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/backend/moamoa/domain/user/oauth/service/CustomUserDetailsService.java
@@ -6,6 +6,7 @@ import com.backend.moamoa.domain.user.repository.UserRepository;
 import com.backend.moamoa.global.exception.CustomException;
 import com.backend.moamoa.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -13,12 +14,14 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info("customUserDetailsService");
         User user = userRepository.findByUserId(username)
                 .orElseThrow(() -> new UsernameNotFoundException("Can not find username."));
 


### PR DESCRIPTION
## 기능 수정 ♻️ 
- 모든 서비스 로직에서 `user`를 찾아오는 부분이 임시로 하드코딩 되어있던 부분 수정했습니다!
- 게시글 단건 조회시 이미지 경로 반환하는 로직을 추가했습니다.

---

## 트러블 슈팅 🔫 
- `API`를 호출할때마다 `UserRepository.findByUserId` 가 2번씩 호출 되길래 로그를 찍어보니 `CustomUserDetailsService` 에서 로그가 2번 찍히더라구요 확인 부탁드립니다!