### PR TITLE
[Feat] 결산 API 추가

### DIFF
--- a/src/main/java/com/backend/moamoa/domain/asset/dto/response/RevenueExpenditureResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/dto/response/RevenueExpenditureResponse.java
@@ -2,6 +2,7 @@ package com.backend.moamoa.domain.asset.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/AssetCategoryRepository.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/AssetCategoryRepository.java
@@ -1,8 +1,10 @@
 package com.backend.moamoa.domain.asset.repository;
 
 import com.backend.moamoa.domain.asset.entity.AssetCategory;
+import com.backend.moamoa.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AssetCategoryRepository extends JpaRepository<AssetCategory, Long>, AssetCategoryRepositoryCustom {
@@ -10,5 +12,7 @@ public interface AssetCategoryRepository extends JpaRepository<AssetCategory, Lo
     Optional<AssetCategory> findByIdAndUserId(Long categoryId, Long id);
 
     Optional<AssetCategory> findByCategoryNameAndUserId(String categoryName, Long id);
+
+    List<AssetCategory> findByUser(User user);
 
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/AssetCategoryRepositoryCustom.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/AssetCategoryRepositoryCustom.java
@@ -6,4 +6,6 @@ public interface AssetCategoryRepositoryCustom {
 
     List<String> findByAssetCategoryTypeAndUserId(String assetCategoryType, Long userId);
 
+    List<String> findByTwoAssetCategoriesAndUserId(String firstType, String secondType, Long userId);
+
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/AssetCategoryRepositoryImpl.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/AssetCategoryRepositoryImpl.java
@@ -23,4 +23,16 @@ public class AssetCategoryRepositoryImpl implements AssetCategoryRepositoryCusto
                 .where(assetCategory.assetCategoryType.eq(AssetCategoryType.valueOf(assetCategoryType.toUpperCase())).and(user.id.eq(userId)))
                 .fetch();
     }
+
+    @Override
+    public List<String> findByTwoAssetCategoriesAndUserId(String firstType, String secondType, Long userId) {
+        return queryFactory
+                .select(assetCategory.categoryName)
+                .from(assetCategory)
+                .innerJoin(assetCategory.user, user)
+                .where((assetCategory.assetCategoryType.eq(AssetCategoryType.valueOf(firstType.toUpperCase()))
+                        .or(assetCategory.assetCategoryType.eq(AssetCategoryType.valueOf(secondType.toUpperCase()))))
+                        .and(user.id.eq(userId)))
+                .fetch();
+    }
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/ExpenditureRatioRepository.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/ExpenditureRatioRepository.java
@@ -1,7 +1,13 @@
 package com.backend.moamoa.domain.asset.repository;
 
 import com.backend.moamoa.domain.asset.entity.ExpenditureRatio;
+import com.backend.moamoa.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ExpenditureRatioRepository extends JpaRepository<ExpenditureRatio, Long> {
+
+    Optional<ExpenditureRatio> findByUser(User user);
+
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/RevenueExpenditureRepository.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/RevenueExpenditureRepository.java
@@ -1,8 +1,22 @@
 package com.backend.moamoa.domain.asset.repository;
 
 import com.backend.moamoa.domain.asset.entity.RevenueExpenditure;
+import com.backend.moamoa.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface RevenueExpenditureRepository extends JpaRepository<RevenueExpenditure, Long>, RevenueExpenditureRepositoryCustom{
+    @Query("SELECT sum(r.cost) from RevenueExpenditure r where (r.date between :start and :end) " +
+            "and r.revenueExpenditureType = com.backend.moamoa.domain.asset.entity.RevenueExpenditureType.EXPENDITURE " +
+            "and r.user = :user")
+    Integer getExpenditure(LocalDate start, LocalDate end, User user);
+
+    @Query("SELECT sum(r.cost) from RevenueExpenditure r where (r.date between :start and :end) " +
+            "and r.revenueExpenditureType = com.backend.moamoa.domain.asset.entity.RevenueExpenditureType.REVENUE " +
+            "and r.user = :user")
+    Integer getRevenue(LocalDate start, LocalDate end, User user);
 
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/RevenueExpenditureRepositoryCustom.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/RevenueExpenditureRepositoryCustom.java
@@ -14,4 +14,8 @@ public interface RevenueExpenditureRepositoryCustom {
 
     List<RevenueExpenditure> findRevenueExpenditure(LocalDate month, Long userId);
 
+    List<RevenueExpenditure> findRevenueWeekExpenditure(LocalDate week, Long userId);
+
+    List<RevenueExpenditure> findRevenueYearExpenditure(LocalDate year, Long userId);
+
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/RevenueExpenditureRepositoryImpl.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/RevenueExpenditureRepositoryImpl.java
@@ -14,9 +14,11 @@ import java.util.List;
 
 import static com.backend.moamoa.domain.asset.entity.QRevenueExpenditure.revenueExpenditure;
 import static com.backend.moamoa.domain.user.entity.QUser.user;
+import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
+import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
 
 @RequiredArgsConstructor
-public class RevenueExpenditureRepositoryImpl implements RevenueExpenditureRepositoryCustom{
+public class RevenueExpenditureRepositoryImpl implements RevenueExpenditureRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
 
@@ -62,6 +64,28 @@ public class RevenueExpenditureRepositoryImpl implements RevenueExpenditureRepos
                         .and(user.id.eq(userId)))
                 .fetch();
 
+    }
+
+    @Override
+    public List<RevenueExpenditure> findRevenueWeekExpenditure(LocalDate week, Long userId) {
+        return queryFactory
+                .selectFrom(revenueExpenditure)
+                .innerJoin(revenueExpenditure.user, user)
+                .where(revenueExpenditure.date
+                        .between(week, week.plusDays(6))
+                        .and(user.id.eq(userId)))
+                .fetch();
+    }
+
+    @Override
+    public List<RevenueExpenditure> findRevenueYearExpenditure(LocalDate year, Long userId) {
+        return queryFactory
+                .selectFrom(revenueExpenditure)
+                .innerJoin(revenueExpenditure.user, user)
+                .where(revenueExpenditure.date
+                        .between(year.with(firstDayOfYear()), year.with(lastDayOfYear()))
+                        .and(user.id.eq(userId)))
+                .fetch();
     }
 
 }

--- a/src/main/java/com/backend/moamoa/domain/settlement/controller/SettlementController.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/controller/SettlementController.java
@@ -1,0 +1,114 @@
+package com.backend.moamoa.domain.settlement.controller;
+
+import com.backend.moamoa.domain.settlement.dto.response.*;
+import com.backend.moamoa.domain.settlement.dto.response.settle.MonthSettleResponse;
+import com.backend.moamoa.domain.settlement.dto.response.settle.WeekSettleResponse;
+import com.backend.moamoa.domain.settlement.dto.response.settle.YearSettleResponse;
+import com.backend.moamoa.domain.settlement.dto.response.total.ComparisonsResponse;
+import com.backend.moamoa.domain.settlement.service.SettlementService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Api(tags = "결산 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/settlement")
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    /**
+     * 주의 시작 날짜를 입력받아, 지난 혹은 미래의 8개의 데이터를 가져와 출력합니다.
+     * @return
+     */
+    @GetMapping("/week")
+    @ApiOperation(value = "가계부 주별 결산", notes = "입력받은 주의 속한 날짜를 기준으로 8개의 데이터를 출력합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "date", value = "해당 주의 속한 날짜(입력하지 않으면 현재 날짜로 설정 합니다.)", example = "2022-04-11", required = false),
+            @ApiImplicitParam(name = "type", value = "과거 데이터 출력(left), 미래 데이터 출력(right)", example = "left", required = true)
+    })
+    public List<WeekSettleResponse> getWeekExpenditure(@RequestParam(required = false) String date, @RequestParam String type) {
+        return settlementService.getWeekExpenditure(date, type);
+    }
+
+    @GetMapping("/week/detail")
+    @ApiOperation(value = "가계부 주 자세한 결산 내역", notes = "입력받은 날짜를 기준으로 해당 주의 자세한 결산 내역을 출력합니다.")
+    @ApiImplicitParam(name = "date", value = "출력하고자 하는 주의 시작 날짜를 입력해주세요.", example = "2022-04-21", required = true)
+    public WeekResponse getWeekDetail(@RequestParam String date) {
+        return settlementService.getWeekDetail(date);
+    }
+
+    /**
+     * 달를 입력받아 지난 주의 5개의 데이터를 가져와 출력합니다.
+     * @return
+     */
+    @GetMapping("/month")
+    @ApiOperation(value = "가계부 달별결산", notes = "입력받은 년과 월를 기준으로 5개의 데이터를 가져와 주별 결산을 출력합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "date", value = "해당 년 월 (입력하지 않으면 현재 날짜로 설정합니다.)", example = "2022-04", required = false),
+            @ApiImplicitParam(name = "type", value = "달 기준 과거 데이터 출력(left), 미래 데이터 출력(right)", example = "left", required = true)
+    })
+    public List<MonthSettleResponse> getMonthExpenditure(@RequestParam(required = false) String date, @RequestParam String type) {
+        return settlementService.getMonthExpenditure(date, type);
+    }
+
+    /**
+     * 년과 달을 입력받아 자세한 결산을 출력합니다.
+     * @return
+     */
+    @GetMapping("/detail")
+    @ApiOperation(value = "가계부 달,년 자세한 결산 내역", notes = "입력받은 달,년을 기준으로 해당 날짜의 자세한 결산 내역을 출력합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "date", value = "해당 달, 년 (달을 출력하려면 2022-04, 년을 출력하려면 2022 형식으로 입력해주세요.)", example = "2022-04", required = true),
+            @ApiImplicitParam(name = "type", value = "달이면 month, 년이면 year을 입력해주세요.", example = "month", required = true)
+    })
+    public MonthResponse getDetail(@RequestParam String date, @RequestParam String type) {
+        return settlementService.getDetail(date, type);
+    }
+
+    /**
+     * 년과 달을 입력받아 지난 달의 5개의 데이터를 가져와 출력합니다.
+     * @return
+     */
+    @GetMapping("/year")
+    @ApiOperation(value = "가계부 년별결산", notes = "입력받은 년을 기준으로 지난 년(일년 격차)의 5개의 데이터를 가져와 년별 결산을 출력합니다.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "date", value = "해당 년(입력하지 않으면 현재 날짜로 설정합니다.)", example = "2022", required = false),
+            @ApiImplicitParam(name = "type", value = "년 기준 과거 데이터 출력(LEFT), 미래 데이터 출력(RIGHT)", example = "LEFT", required = true)
+    })
+    public List<YearSettleResponse> getYearExpenditure(@RequestParam(required = false) String date, @RequestParam String type) {
+        return settlementService.getYearExpenditure(date, type);
+    }
+
+    /**
+     * 전 달 데이터와 비교하여 데이터를 출력합니다.
+     * @return
+     */
+    @GetMapping("/month/comparison")
+    @ApiOperation(value = "지난 달과 비교하기", notes = "입력받은 년과 월를 기준으로 지난 달 데이터를 가져와 비교합니다.")
+    @ApiImplicitParam(name = "date", value = "해당 년 월", example = "2022-04", required = true)
+    public ComparisonsResponse getMonthComparison(@RequestParam String date) {
+        return settlementService.getMonthComparison(date);
+    }
+
+    /**
+     * 전 년 데이터와 비교하여 데이터를 출력합니다.
+     * @return
+     */
+    @GetMapping("/year/comparison")
+    @ApiOperation(value = "지난 년과 비교하기", notes = "입력받은 년을 기준으로 지난 년의 데이터를 가져와 비교합니다.")
+    @ApiImplicitParam(name = "date", value = "해당 년", example = "2022", required = true)
+    public ComparisonsResponse getYearComparison(@RequestParam String date) {
+        return settlementService.getYearComparison(date);
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/CostResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/CostResponse.java
@@ -1,0 +1,37 @@
+package com.backend.moamoa.domain.settlement.dto.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+@ApiModel(description = "고정 비용 응답 모델")
+public class CostResponse {
+
+    @ApiModelProperty(value = "총 비용", example = "15000")
+    private int totalCost;
+
+    @ApiModelProperty(value = "총 퍼센트", example = "84")
+    private int totalPercent;
+
+    @ApiModelProperty(value = "비용 카테고리", example = "통신비")
+    private String CategoryName;
+
+    @ApiModelProperty(value = "지출 비용", example = "15000")
+    private int cost;
+
+    @ApiModelProperty(value = "퍼센트", example = "34")
+    private int percent;
+
+    @Builder
+    public CostResponse(int totalCost, int totalPercent, String categoryName, int cost, int percent) {
+        this.totalCost = totalCost;
+        this.totalPercent = totalPercent;
+        this.CategoryName = categoryName;
+        this.cost = cost;
+        this.percent = percent;
+    }
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/MonthResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/MonthResponse.java
@@ -1,0 +1,49 @@
+package com.backend.moamoa.domain.settlement.dto.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import java.util.List;
+
+@ApiModel(description = "달 별 결산 응답 모델")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class MonthResponse
+{
+
+    @ApiModelProperty(value = "최대 지출 카테고리", example = "식비")
+    private String mostExpCategory;
+
+    @ApiModelProperty(value = "최소 지출 카테고리", example = "기타")
+    private String leastExpCategory;
+
+    @ApiModelProperty(value = "총 지출 내역", example = "15000")
+    private int totalExp;
+
+    @ApiModelProperty(value = "총 수익 내역", example = "15000")
+    private int totalRevenue;
+
+    private List<CostResponse> fixedCostResponses;
+
+    private List<CostResponse> variableCostResponses;
+
+    private List<RevenueResponse> revenueResponses;
+
+    @ApiModelProperty(value = "총 순이익", example = "15000")
+    private Integer netIncome;
+
+    @ApiModelProperty(value = "고정 비율 초과 여부", example = "true")
+    private Boolean fixedExceed;
+
+    @ApiModelProperty(value = "변동 비율 초과 여부", example = "true")
+    private Boolean variableExceed;
+
+    public MonthResponse() {
+        this.fixedExceed = false;
+        this.variableExceed = false;
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/RevenueResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/RevenueResponse.java
@@ -1,0 +1,24 @@
+package com.backend.moamoa.domain.settlement.dto.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@ApiModel(description = "수익 응답 모델")
+public class RevenueResponse {
+
+    @ApiModelProperty(value = "수익 카테고리", example = "월급")
+    private String CategoryName;
+
+    @ApiModelProperty(value = "수익 비용", example = "15000")
+    private int revenue;
+
+    @ApiModelProperty(value = "수익 퍼센트", example = "34")
+    private int percent;
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/TotalResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/TotalResponse.java
@@ -1,0 +1,35 @@
+package com.backend.moamoa.domain.settlement.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TotalResponse {
+
+    int totalExp;
+
+    int totalRevenue;
+
+    int totalFixed;
+
+    int totalVariable;
+
+    public void setTotalResponse(String revenueExpenditureType, String categoryName, int cost) {
+        if (revenueExpenditureType.equals("REVENUE")) {
+            this.totalRevenue += cost;
+        }
+        if (revenueExpenditureType.equals("EXPENDITURE")) {
+            this.totalExp += cost;
+        }
+        if (categoryName.equals("FIXED")) {
+            this.totalFixed += cost;
+        }
+        if (categoryName.equals("VARIABLE")) {
+            this.totalVariable += cost;
+        }
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/WeekResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/WeekResponse.java
@@ -1,0 +1,43 @@
+package com.backend.moamoa.domain.settlement.dto.response;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import java.util.List;
+
+@ApiModel(description = "주 별 결산 응답 모델")
+@Getter
+@Setter
+@NoArgsConstructor
+public class WeekResponse
+{
+
+    @ApiModelProperty(value = "해당 날짜의 년", example = "2022")
+    private Integer year;
+
+    @ApiModelProperty(value = "해당 날짜의 주차", example = "3")
+    private Integer weekOfMonth;
+
+    @ApiModelProperty(value = "최대 지출 카테고리", example = "식비")
+    private String mostExpCategory;
+
+    @ApiModelProperty(value = "최소 지출 카테고리", example = "기타")
+    private String leastExpCategory;
+
+    @ApiModelProperty(value = "총 지출 내역", example = "15000")
+    private int totalExp;
+
+    private List<CostResponse> fixedCostResponses;
+
+    @Builder
+    public WeekResponse(Integer year, Integer weekOfMonth, String mostExpCategory, String leastExpCategory, int totalExp, List<CostResponse> fixedCostResponses) {
+        this.year = year;
+        this.weekOfMonth = weekOfMonth;
+        this.mostExpCategory = mostExpCategory;
+        this.leastExpCategory = leastExpCategory;
+        this.totalExp = totalExp;
+        this.fixedCostResponses = fixedCostResponses;
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/MonthSettleResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/MonthSettleResponse.java
@@ -17,10 +17,10 @@ public class MonthSettleResponse {
     private int year;
 
     @ApiModelProperty(value = "지출 내역", example = "15000")
-    private Integer cost;
+    private int cost;
 
     @ApiModelProperty(value = "수익 내역", example = "15000")
-    private Integer revenue;
+    private int revenue;
 
     @Builder
     public MonthSettleResponse(int month, int year, Integer cost, Integer revenue) {

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/MonthSettleResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/MonthSettleResponse.java
@@ -1,0 +1,33 @@
+package com.backend.moamoa.domain.settlement.dto.response.settle;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@ApiModel(description = "달별 결산 응답 모델")
+@Getter
+@Setter
+@NoArgsConstructor
+public class MonthSettleResponse {
+
+    @ApiModelProperty(value = "해당 달", example = "3")
+    private int month;
+
+    @ApiModelProperty(value = "해당 년", example = "2022")
+    private int year;
+
+    @ApiModelProperty(value = "지출 내역", example = "15000")
+    private Integer cost;
+
+    @ApiModelProperty(value = "수익 내역", example = "15000")
+    private Integer revenue;
+
+    @Builder
+    public MonthSettleResponse(int month, int year, Integer cost, Integer revenue) {
+        this.month = month;
+        this.year = year;
+        this.cost = (cost == null) ? 0 : cost;
+        this.revenue = (revenue == null) ? 0 : revenue;
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/WeekSettleResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/WeekSettleResponse.java
@@ -1,0 +1,46 @@
+package com.backend.moamoa.domain.settlement.dto.response.settle;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@ApiModel(description = "주별 결산 응답 모델")
+@Getter
+@Setter
+@NoArgsConstructor
+public class WeekSettleResponse {
+
+    @ApiModelProperty(value = "해당 년", example = "2022")
+    private Integer year;
+
+    @ApiModelProperty(value = "해당 달", example = "3")
+    private Integer month;
+
+    @ApiModelProperty(value = "해당 주차", example = "4")
+    private Integer dayOfWeek;
+
+    @ApiModelProperty(value = "지출 내역", example = "15000")
+    private Integer cost;
+
+    @ApiModelProperty(value = "시작 년 월 일", example = "15000")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate weekStart;
+
+    @ApiModelProperty(value = "끝 년 월 일", example = "15000")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate weekEnd;
+
+    @Builder
+    public WeekSettleResponse(int year, int month, int dayOfWeek, Integer cost, LocalDate weekStart, LocalDate weekEnd) {
+        this.year = year;
+        this.month = month;
+        this.dayOfWeek = dayOfWeek;
+        this.cost = (cost == null) ? 0 : cost;
+        this.weekStart = weekStart;
+        this.weekEnd = weekEnd;
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/WeekSettleResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/WeekSettleResponse.java
@@ -23,7 +23,7 @@ public class WeekSettleResponse {
     private Integer dayOfWeek;
 
     @ApiModelProperty(value = "지출 내역", example = "15000")
-    private Integer cost;
+    private int cost;
 
     @ApiModelProperty(value = "시작 년 월 일", example = "15000")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/YearSettleResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/settle/YearSettleResponse.java
@@ -1,0 +1,32 @@
+package com.backend.moamoa.domain.settlement.dto.response.settle;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@ApiModel(description = "년별 결산 응답 모델")
+@Getter
+@Setter
+@NoArgsConstructor
+public class YearSettleResponse {
+
+    @ApiModelProperty(value = "해당 년", example = "2022")
+    private Integer year;
+
+    @ApiModelProperty(value = "지출 내역", example = "15000")
+    private Integer cost;
+
+    @ApiModelProperty(value = "수익 내역", example = "15000")
+    private Integer revenue;
+
+    @Builder
+    public YearSettleResponse(int year, Integer cost, Integer revenue) {
+        this.year = year;
+        this.cost = (cost == null) ? 0 : cost;
+        this.revenue = (revenue == null) ? 0 : revenue;
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/total/ComparisonResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/total/ComparisonResponse.java
@@ -1,0 +1,29 @@
+package com.backend.moamoa.domain.settlement.dto.response.total;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ComparisonResponse {
+
+    private String content;
+
+    private int previous;
+
+    private int present;
+
+    private int difference;
+
+    private int ratio;
+
+    @Builder
+    public ComparisonResponse(String content, int prev, int present, int difference, int ratio) {
+        this.content = content;
+        this.previous = prev;
+        this.present = present;
+        this.difference = difference;
+        this.ratio = ratio;
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/total/ComparisonsResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/total/ComparisonsResponse.java
@@ -1,0 +1,29 @@
+package com.backend.moamoa.domain.settlement.dto.response.total;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+public class ComparisonsResponse {
+
+    private ComparisonResponse totalExpResponse;
+
+    private List<TotalComparisonResponse> fixedResponses;
+
+    private List<TotalComparisonResponse> varianceResponses;
+
+    private ComparisonResponse netProfitResponse;
+
+    @Builder
+    public ComparisonsResponse(ComparisonResponse totalExpResponse, List<TotalComparisonResponse> fixedResponses, List<TotalComparisonResponse> varianceResponses, ComparisonResponse netProfitResponse) {
+        this.totalExpResponse = totalExpResponse;
+        this.fixedResponses = fixedResponses;
+        this.varianceResponses = varianceResponses;
+        this.netProfitResponse = netProfitResponse;
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/dto/response/total/TotalComparisonResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/dto/response/total/TotalComparisonResponse.java
@@ -1,0 +1,22 @@
+package com.backend.moamoa.domain.settlement.dto.response.total;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TotalComparisonResponse {
+
+    private ComparisonResponse categoryType;
+
+    private ComparisonResponse categoryName;
+
+    @Builder
+    public TotalComparisonResponse(ComparisonResponse categoryType, ComparisonResponse categoryName) {
+        this.categoryType = categoryType;
+        this.categoryName = categoryName;
+    }
+}

--- a/src/main/java/com/backend/moamoa/domain/settlement/service/SettlementService.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/service/SettlementService.java
@@ -1,0 +1,402 @@
+package com.backend.moamoa.domain.settlement.service;
+
+import com.backend.moamoa.domain.settlement.dto.response.*;
+import com.backend.moamoa.domain.settlement.dto.response.settle.MonthSettleResponse;
+import com.backend.moamoa.domain.settlement.dto.response.settle.WeekSettleResponse;
+import com.backend.moamoa.domain.settlement.dto.response.settle.YearSettleResponse;
+import com.backend.moamoa.domain.settlement.dto.response.total.ComparisonsResponse;
+import com.backend.moamoa.domain.settlement.dto.response.total.TotalComparisonResponse;
+import com.backend.moamoa.domain.settlement.dto.response.total.ComparisonResponse;
+import com.backend.moamoa.domain.asset.entity.ExpenditureRatio;
+import com.backend.moamoa.domain.asset.entity.RevenueExpenditure;
+import com.backend.moamoa.domain.asset.repository.AssetCategoryRepository;
+import com.backend.moamoa.domain.asset.repository.ExpenditureRatioRepository;
+import com.backend.moamoa.domain.asset.repository.RevenueExpenditureRepository;
+import com.backend.moamoa.domain.user.entity.User;
+import com.backend.moamoa.global.exception.CustomException;
+import com.backend.moamoa.global.exception.ErrorCode;
+import com.backend.moamoa.global.utils.UserUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAdjusters;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.time.temporal.TemporalAdjusters.firstDayOfYear;
+import static java.time.temporal.TemporalAdjusters.lastDayOfYear;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SettlementService {
+
+    private static final String TYPE_REVENUE = "REVENUE";
+    private static final String TYPE_EXPENDITURE = "EXPENDITURE";
+    private static final String TYPE_NET_PROFIT = "NET_PROFIT";
+    private static final String TYPE_FIXED = "FIXED";
+    private static final String TYPE_VARIABLE = "VARIABLE";
+
+    private final RevenueExpenditureRepository revenueExpenditureRepository;
+    private final ExpenditureRatioRepository expenditureRatioRepository;
+    private final AssetCategoryRepository assetCategoryRepository;
+    private final UserUtil userUtil;
+
+    // 주별 지출 내역 출력
+    public List<WeekSettleResponse> getWeekExpenditure(String date, String type) {
+        User user = userUtil.findCurrentUser();
+        LocalDate standard;
+
+        if (date == null) {
+            standard = LocalDate.now();
+        } else {
+            standard = LocalDate.parse(date);
+        }
+
+        LocalDate startDate = standard.with(ChronoField.ALIGNED_WEEK_OF_YEAR, standard.get(ChronoField.ALIGNED_WEEK_OF_YEAR))
+                .with(DayOfWeek.MONDAY);
+        LocalDate endDate = startDate.plusDays(6);
+
+        Integer weekNumber = getWeekNumber(standard);
+        List<WeekSettleResponse> weekSettleResponses = new ArrayList<>();
+
+        for (int i = 0; i < 8; i++) {
+            Integer cost = revenueExpenditureRepository.getExpenditure(startDate, endDate, user);
+
+            WeekSettleResponse weekSettleResponse = new WeekSettleResponse(standard.getYear(), standard.getMonthValue(), weekNumber, cost, startDate, endDate);
+            weekSettleResponses.add(weekSettleResponse);
+
+            if (type.equals("left")) {
+                weekNumber = weekNumber - 1;
+                startDate = startDate.minusWeeks(1);
+                endDate = endDate.minusWeeks(1);
+                if (weekNumber <= 0) {
+                    standard = standard.minusMonths(1);
+                    weekNumber = getWeekNumber(standard.with(TemporalAdjusters.lastDayOfMonth()));
+                }
+            } else {
+                weekNumber = weekNumber + 1;
+                startDate = startDate.plusWeeks(1);
+                endDate = endDate.plusWeeks(1);
+                if (weekNumber > getWeekNumber(standard.with(TemporalAdjusters.lastDayOfMonth()))) {
+                    standard = standard.plusMonths(1);
+                    weekNumber = 1;
+                }
+            }
+        }
+        return weekSettleResponses;
+    }
+
+    // 달별 지출 내역 출력
+    public List<MonthSettleResponse> getMonthExpenditure(String date, String type) {
+        User user = userUtil.findCurrentUser();
+        LocalDate standard;
+
+        if (date == null) {
+            standard = LocalDate.now();
+        } else {
+            standard = LocalDate.parse(date + "-01");
+        }
+        List<MonthSettleResponse> monthSettleResponses = new ArrayList<>();
+
+        for (int i = 0; i < 5; i++) {
+            int year = standard.getYear();
+            int month = standard.getMonthValue();
+
+            LocalDate monthStart = LocalDate.of(year, month, 1);
+            LocalDate monthEnd = monthStart.plusDays(monthStart.lengthOfMonth() - 1);
+
+            Integer cost = revenueExpenditureRepository.getExpenditure(monthStart, monthEnd, user);
+            Integer revenue = revenueExpenditureRepository.getRevenue(monthStart, monthEnd, user);
+
+            MonthSettleResponse monthSettleResponse = new MonthSettleResponse(month, year, cost, revenue);
+            monthSettleResponses.add(monthSettleResponse);
+
+            if (type.equals("left")) {
+                standard = standard.minusMonths(1);
+            } else {
+                standard = standard.plusMonths(1);
+            }
+        }
+        return monthSettleResponses;
+    }
+
+    // 달, 년 별 자세한 지출 내역 출력
+    public MonthResponse getDetail(String date, String type) {
+
+        User user = userUtil.findCurrentUser();
+        List<RevenueExpenditure> revenueExpenditure;
+
+        if (type.equals("month")) {
+            revenueExpenditure = revenueExpenditureRepository.findRevenueExpenditure(LocalDate.parse(date + "-01"), user.getId());
+        } else {
+            revenueExpenditure = revenueExpenditureRepository.findRevenueYearExpenditure(LocalDate.parse(date + "-01-01"), user.getId());
+        }
+
+        Integer totalExp = getRevenueExpenditure(revenueExpenditure, TYPE_EXPENDITURE);
+        Integer totalRevenue = getRevenueExpenditure(revenueExpenditure, TYPE_REVENUE);
+        Integer totalFixed = getExpenditureByCategory(revenueExpenditure, TYPE_FIXED);
+        Integer totalVariable = getExpenditureByCategory(revenueExpenditure, TYPE_VARIABLE);
+
+        int totalFixedPercent = (int) ((double) totalFixed / totalExp * 100.0);
+        int totalVariablePercent = (int) ((double) totalVariable / totalExp * 100.0);
+
+        List<String> fixed = assetCategoryRepository.findByAssetCategoryTypeAndUserId(TYPE_FIXED, user.getId());
+        List<String> variable = assetCategoryRepository.findByAssetCategoryTypeAndUserId(TYPE_VARIABLE, user.getId());
+        List<String> revenues = assetCategoryRepository.findByAssetCategoryTypeAndUserId(TYPE_REVENUE, user.getId());
+
+        ExpenditureRatio expenditureRatio = expenditureRatioRepository.findByUser(user).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND_RATIO));
+
+        Boolean fixedExceed = null, variableExceed = null;
+
+        if (type.equals("month")) {
+            fixedExceed = (totalFixedPercent > expenditureRatio.getFixed());
+            variableExceed = (totalVariablePercent > expenditureRatio.getVariable());
+        }
+
+        List<CostResponse> fixedRes = new ArrayList<>();
+        List<CostResponse> costRes = new ArrayList<>();
+        List<RevenueResponse> revenueRes = new ArrayList<>();
+
+        setCostResponse(revenueExpenditure, totalExp, totalFixed, totalFixedPercent, fixed, fixedRes);
+        setCostResponse(revenueExpenditure, totalExp, totalVariable, totalVariablePercent, variable, costRes);
+
+        for (String revenue : revenues) {
+            RevenueResponse revenueResponse =
+                    RevenueResponse.builder()
+                            .CategoryName(revenue)
+                            .revenue(getExpenditureByCost(revenueExpenditure, revenue))
+                            .percent((int) ((double) getExpenditureByCost(revenueExpenditure, revenue) / totalRevenue * 100.0))
+                            .build();
+
+            revenueRes.add(revenueResponse);
+        }
+
+        fixedRes = fixedRes.stream().sorted(Comparator.comparing(CostResponse::getCost).reversed()).collect(Collectors.toList());
+        costRes = costRes.stream().sorted(Comparator.comparing(CostResponse::getCost).reversed()).collect(Collectors.toList());
+
+        List<String> categories = getMostAndLeastCategory(fixedRes, costRes);
+
+        return MonthResponse.builder()
+                .mostExpCategory(categories.get(0))
+                .leastExpCategory(categories.get(1))
+                .totalExp(totalExp)
+                .totalRevenue(totalRevenue)
+                .fixedCostResponses(fixedRes)
+                .variableCostResponses(costRes)
+                .revenueResponses(revenueRes)
+                .netIncome(totalRevenue - totalExp)
+                .fixedExceed(fixedExceed)
+                .variableExceed(variableExceed)
+                .build();
+    }
+
+    // 주의 자세한 지출 내역 출력
+    public WeekResponse getWeekDetail(String date) {
+        User user = userUtil.findCurrentUser();
+        LocalDate standard = LocalDate.parse(date);
+
+        List<RevenueExpenditure> revenueExpenditure = revenueExpenditureRepository.findRevenueWeekExpenditure(standard, user.getId());
+        int totalExp = getRevenueExpenditure(revenueExpenditure, TYPE_EXPENDITURE);
+
+        List<String> categoryNames = assetCategoryRepository.findByTwoAssetCategoriesAndUserId(TYPE_FIXED, TYPE_VARIABLE, user.getId());
+        List<CostResponse> costResponses = new ArrayList<>();
+
+        for (String categoryName : categoryNames) {
+            costResponses.add(
+                    CostResponse.builder()
+                            .totalCost(0)
+                            .totalPercent(0)
+                            .CategoryName(categoryName)
+                            .cost(getExpenditureByCost(revenueExpenditure, categoryName))
+                            .percent((int) ((double) getExpenditureByCost(revenueExpenditure, categoryName) / totalExp * 100.0))
+                            .build()
+            );
+        }
+
+        String mostCategory = null, minCategory = null;
+
+        if (!costResponses.isEmpty()) {
+            costResponses = costResponses.stream()
+                    .sorted(Comparator.comparing(CostResponse::getCost).reversed()).collect(Collectors.toList());
+
+            mostCategory = costResponses.get(0).getCategoryName();
+            minCategory = costResponses.get(costResponses.size() - 1).getCategoryName();
+        }
+
+        return new WeekResponse(standard.getYear(), getWeekNumber(standard), mostCategory, minCategory, totalExp, costResponses);
+    }
+
+    // 달 기준 자세한 지출 내역 비교하기
+    public ComparisonsResponse getMonthComparison(String date) {
+        LocalDate standard = LocalDate.parse(date + "-01");
+        String prev = standard.minusMonths(1).toString().substring(0, 7);
+
+        MonthResponse prevRes = getDetail(prev, "month");
+        MonthResponse presentRes = getDetail(date, "month");
+
+        return getComparisonRes(prevRes, presentRes);
+    }
+
+    // 년 기준 자세한 지출 내역 비교하기
+    public ComparisonsResponse getYearComparison(String date) {
+        LocalDate standard = LocalDate.parse(date + "-01-01");
+        String prev = standard.minusYears(1).toString().substring(0, 4);
+
+        MonthResponse prevRes = getDetail(prev, "year");
+        MonthResponse presentRes = getDetail(date, "year");
+
+        return getComparisonRes(prevRes, presentRes);
+    }
+
+    // 달, 년 자세한 지출 내역 비교하기
+    private ComparisonsResponse getComparisonRes(MonthResponse prevRes, MonthResponse presentRes) {
+
+        ComparisonResponse totalExp = getComparisonResponse(prevRes.getTotalExp(), presentRes.getTotalExp(), TYPE_EXPENDITURE);
+
+        List<TotalComparisonResponse> totalFixedResponses = new ArrayList<>();
+        List<CostResponse> fixedPrev = prevRes.getFixedCostResponses();
+        List<CostResponse> fixedPresent = presentRes.getFixedCostResponses();
+        setTotalComparisonResponse(fixedPrev, fixedPresent, totalFixedResponses, TYPE_FIXED);
+
+        List<TotalComparisonResponse> totalVarResponses = new ArrayList<>();
+        List<CostResponse> varPrev = prevRes.getVariableCostResponses();
+        List<CostResponse> varPresent = presentRes.getVariableCostResponses();
+        setTotalComparisonResponse(varPrev, varPresent, totalVarResponses, TYPE_VARIABLE);
+
+        ComparisonResponse netResponse = getComparisonResponse(prevRes.getTotalRevenue() - prevRes.getTotalExp(),
+                presentRes.getTotalRevenue() - presentRes.getTotalExp(), TYPE_NET_PROFIT);
+
+        return new ComparisonsResponse(totalExp, totalFixedResponses, totalVarResponses, netResponse);
+    }
+
+    // 년 지출 내역 구하기
+    public List<YearSettleResponse> getYearExpenditure(String date, String type) {
+
+        User user = userUtil.findCurrentUser();
+        LocalDate standard;
+
+        if (date == null) {
+            standard = LocalDate.now();
+        } else {
+            standard = LocalDate.parse(date + "-01-01");
+        }
+        List<YearSettleResponse> yearSettleResponses = new ArrayList<>();
+
+        for (int i = 0; i < 5; i++) {
+
+            int year = standard.getYear();
+            LocalDate yearStart = standard.with(firstDayOfYear());
+            LocalDate yearEnd = standard.with(lastDayOfYear());
+
+            Integer cost = revenueExpenditureRepository.getExpenditure(yearStart, yearEnd, user);
+            Integer revenue = revenueExpenditureRepository.getRevenue(yearStart, yearEnd, user);
+
+            YearSettleResponse yearSettleResponse = new YearSettleResponse(year, cost, revenue);
+            yearSettleResponses.add(yearSettleResponse);
+
+            if (type.equals("LEFT")) {
+                standard = standard.minusYears(1);
+            } else {
+                standard = standard.plusYears(1);
+            }
+        }
+        return yearSettleResponses;
+    }
+
+    private ComparisonResponse getComparisonResponse(int prevTotal, int presentTotal, String type) {
+        int diff = presentTotal - prevTotal;
+        int ratio = getRatio(diff, prevTotal);
+
+        return new ComparisonResponse(type, prevTotal, presentTotal, diff, ratio);
+    }
+
+    private void setTotalComparisonResponse(List<CostResponse> prevLists, List<CostResponse> presentLists, List<TotalComparisonResponse> responses, String type) {
+        for (int i = 0; i < presentLists.size(); i++) {
+            int difference = presentLists.get(i).getCost() - prevLists.get(i).getCost();
+            int ratio = getRatio(difference, prevLists.get(i).getCost());
+
+            ComparisonResponse categoryName = new ComparisonResponse(presentLists.get(i).getCategoryName(), prevLists.get(i).getCost(), presentLists.get(i).getCost(), difference, ratio);
+            ComparisonResponse categoryType = new ComparisonResponse(type, prevLists.get(i).getTotalCost(), presentLists.get(i).getTotalCost(), presentLists.get(i).getTotalCost() - prevLists.get(i).getTotalCost(), getRatio(presentLists.get(i).getTotalCost() - prevLists.get(i).getTotalCost(), prevLists.get(i).getTotalCost()));
+
+            TotalComparisonResponse response = new TotalComparisonResponse(categoryType, categoryName);
+            responses.add(response);
+        }
+    }
+
+    private int getRatio(int difference, int prev) {
+        if (prev != 0) {
+            if(prev < 0)
+                return (int) ((double) difference / (double) prev * 100.0) * -1;
+            else
+                return (int) ((double) difference / (double) prev * 100.0);
+        } else {
+            if (difference == 0) return 0;
+            else if (difference > 0) return 100;
+            else return -100;
+        }
+    }
+
+    private int getRevenueExpenditure(List<RevenueExpenditure> revenueExpenditureList, String type) {
+        return revenueExpenditureList.stream().filter(r -> r.getRevenueExpenditureType().toString().equals(type)).mapToInt(RevenueExpenditure::getCost).sum();
+    }
+
+    private int getExpenditureByCategory(List<RevenueExpenditure> revenueExpenditureList, String category) {
+        return revenueExpenditureList.stream().filter(r -> r.getCategoryName().equals(category)).mapToInt(RevenueExpenditure::getCost).sum();
+    }
+
+    private int getExpenditureByCost(List<RevenueExpenditure> revenueExpenditureList, String cost) {
+        return revenueExpenditureList.stream().filter(r -> r.getContent().equals(cost)).mapToInt(RevenueExpenditure::getCost).sum();
+    }
+
+    private List<String> getMostAndLeastCategory(List<CostResponse> fixedRes, List<CostResponse> costRes) {
+
+        CostResponse maxFixed = fixedRes.get(0);
+        CostResponse maxVar = costRes.get(0);
+
+        CostResponse minFixed = fixedRes.get(fixedRes.size() - 1);
+        CostResponse minVar = costRes.get(costRes.size() - 1);
+
+        String maxName = maxFixed.getCost() >= maxVar.getCost() ? maxFixed.getCategoryName() : maxVar.getCategoryName();
+        String minName = minFixed.getCost() >= minVar.getCost() ? minVar.getCategoryName() : maxFixed.getCategoryName();
+
+        List<String> nameList = new ArrayList<>();
+        nameList.add(maxName);
+        nameList.add(minName);
+
+        return nameList;
+    }
+
+    public Integer getWeekNumber(LocalDate date) {
+        LocalDate firstMondayOfMonth = date.with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY));
+
+        // 첫 월요일이면 바로 리턴
+        if (firstMondayOfMonth.isEqual(date)) return 1;
+
+        if (date.isAfter(firstMondayOfMonth)) {
+            // 첫 월요일 이후일 때
+            int diffFromFirstMonday = date.getDayOfMonth() - firstMondayOfMonth.getDayOfMonth();
+            int weekNumber = (int) Math.ceil(diffFromFirstMonday / 7.0);
+            if (date.getDayOfWeek() == DayOfWeek.MONDAY) weekNumber += 1;
+            return weekNumber;
+        }
+        // 첫 월요일 이전이면 회귀식으로 전 달 마지막 주차를 구함
+        return getWeekNumber(date.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth()));
+    }
+
+    private void setCostResponse(List<RevenueExpenditure> revenueExpenditure,
+                                 int totalExp, int totalCost, int percent, List<String> names, List<CostResponse> lists) {
+        for (String name : names) {
+            CostResponse costResponse = new CostResponse(totalCost, percent, name, getExpenditureByCost(revenueExpenditure, name),
+                    (int) ((double) getExpenditureByCost(revenueExpenditure, name) / (double) totalExp * 100.0));
+
+            lists.add(costResponse);
+        }
+    }
+
+}

--- a/src/main/java/com/backend/moamoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/backend/moamoa/global/exception/ErrorCode.java
@@ -34,7 +34,9 @@ public enum ErrorCode {
 
     ALREADY_NICKNAME_EXISTS(HttpStatus.ALREADY_REPORTED, "이미 존재하는 닉네임입니다."),
 
-    ALREADY_PHONE_NUM_EXISTS(HttpStatus.ALREADY_REPORTED, "이미 존재하는 휴대폰 번호 입니다.");
+    ALREADY_PHONE_NUM_EXISTS(HttpStatus.ALREADY_REPORTED, "이미 존재하는 휴대폰 번호 입니다."),
+
+    NOT_FOUND_RATIO(HttpStatus.NOT_FOUND, "지출 비율을 찾을 수 없습니다.");
 
 
 


### PR DESCRIPTION
## 결산 API 추가  
- 가계부 주, 달, 년 별 결산 API 추가
- 가계부 주, 달, 년 자세한 결산 내역 보기 API 추가
- 지난 달, 년 비교하기 API 추가했습니다.

<img width="930" alt="캡처" src="https://user-images.githubusercontent.com/60867950/164644228-efe6695d-4591-49ba-9df9-32badd2513da.PNG">


## 현 상황 및 예정
- 아직 쿼리 불러오기 및 내부 서비스 로직이 복잡하여, 추후에 많은 리팩토링을 거칠 예정입니다. 
- github action을 적용하여 CI/CD를 구축할 예정입니다.