### PR TITLE
Feat : 머니로그 테이블 설계 및 간단한 작성 API

### DIFF
--- a/src/main/java/com/backend/moamoa/domain/asset/controller/AssetController.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/controller/AssetController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -98,9 +99,21 @@ public class AssetController {
         return ResponseEntity.ok(assetService.findRevenueExpenditureByMonth(month, pageable));
     }
 
+    @ApiOperation(value = "자산 관리 목표 작성", notes = "해당 년, 월을 입력받아 자산 관리 목표를 작성하는 API")
+    @ApiResponse(responseCode = "200", description = "해당 자산 관리 목표를 정상적으로 추가한 경우")
     @PutMapping("/asset-goal")
     public ResponseEntity<CreateAssetGoalResponse> addAssetGoal(@RequestBody CreateAssetGoalRequest request) {
         return ResponseEntity.ok(new CreateAssetGoalResponse(assetService.addAssetGoal(request)));
     }
 
+    @ApiOperation(value = "머니 로그 작성", notes = "날짜, 내용, 이미지 파일을 입력받아 머니로 그를 작성하는 API",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "머니 로그 작성이 정상적으로 추가된 경우"),
+            @ApiResponse(responseCode = "404", description = "회원 Id를 찾지 못한 경우")
+    })
+    @PostMapping("/money-log")
+    public ResponseEntity<CreateMoneyLogResponse> createMoneyLog(@Validated @ModelAttribute CreateMoneyLogRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(assetService.createMoneyLog(request));
+    }
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/controller/AssetController.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/controller/AssetController.java
@@ -1,9 +1,6 @@
 package com.backend.moamoa.domain.asset.controller;
 
-import com.backend.moamoa.domain.asset.dto.request.AssetCategoryRequest;
-import com.backend.moamoa.domain.asset.dto.request.BudgetRequest;
-import com.backend.moamoa.domain.asset.dto.request.CreateRevenueExpenditureRequest;
-import com.backend.moamoa.domain.asset.dto.request.ExpenditureRequest;
+import com.backend.moamoa.domain.asset.dto.request.*;
 import com.backend.moamoa.domain.asset.dto.response.*;
 import com.backend.moamoa.domain.asset.service.AssetService;
 import io.swagger.annotations.Api;
@@ -99,6 +96,11 @@ public class AssetController {
     @GetMapping("/revenueExpenditure")
     public ResponseEntity<RevenueExpenditureSumResponse> getRevenueExpenditures(@RequestParam String month, Pageable pageable) {
         return ResponseEntity.ok(assetService.findRevenueExpenditureByMonth(month, pageable));
+    }
+
+    @PutMapping("/asset-goal")
+    public ResponseEntity<CreateAssetGoalResponse> addAssetGoal(@RequestBody CreateAssetGoalRequest request) {
+        return ResponseEntity.ok(new CreateAssetGoalResponse(assetService.addAssetGoal(request)));
     }
 
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/dto/request/CreateAssetGoalRequest.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/dto/request/CreateAssetGoalRequest.java
@@ -1,0 +1,22 @@
+package com.backend.moamoa.domain.asset.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAssetGoalRequest {
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private LocalDate date;
+
+    private String content;
+
+}

--- a/src/main/java/com/backend/moamoa/domain/asset/dto/request/CreateAssetGoalRequest.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/dto/request/CreateAssetGoalRequest.java
@@ -1,6 +1,8 @@
 package com.backend.moamoa.domain.asset.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,15 +10,18 @@ import lombok.Setter;
 
 import java.time.LocalDate;
 
+@ApiModel(description = "자산 관리 목표 요청 데이터 모델")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateAssetGoalRequest {
 
+    @ApiModelProperty(value = "해당 년, 월, 일", example = "2022-04-23", required = true)
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDate date;
 
+    @ApiModelProperty(value = "자산 관리 목표 내용", example = "100만원 적금 하기!", required = true)
     private String content;
 
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/dto/request/CreateMoneyLogRequest.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/dto/request/CreateMoneyLogRequest.java
@@ -1,0 +1,34 @@
+package com.backend.moamoa.domain.asset.dto.request;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@ApiModel(description = "머니 로그 작성 요청 데이터 모델")
+@Getter
+@Setter
+@NoArgsConstructor
+public class CreateMoneyLogRequest {
+
+    @ApiModelProperty(value = "해당 년, 월, 일", example = "2022-04-23", required = true)
+    @NotNull
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    @ApiModelProperty(value = "머니 로그 작성 내용", example = "오늘은 떡볶이를 먹었다!", required = true)
+    @NotNull
+    private String content;
+
+    @ApiModelProperty(value = "이미지 파일")
+    private List<MultipartFile> imageFiles = new ArrayList<>();
+
+}

--- a/src/main/java/com/backend/moamoa/domain/asset/dto/response/CreateAssetGoalResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/dto/response/CreateAssetGoalResponse.java
@@ -1,0 +1,16 @@
+package com.backend.moamoa.domain.asset.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateAssetGoalResponse {
+
+    private Long assetGoalId;
+
+}

--- a/src/main/java/com/backend/moamoa/domain/asset/dto/response/CreateMoneyLogResponse.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/dto/response/CreateMoneyLogResponse.java
@@ -7,15 +7,20 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @ApiModel(description = "응답 데이터 모델")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateAssetGoalResponse {
+public class CreateMoneyLogResponse {
 
-    @ApiModelProperty(value = "자산 관리 목표 생성 ID")
-    private Long assetGoalId;
+    @ApiModelProperty(value = "머니 로그 생성 ID")
+    private Long moneyLogId;
 
+    @ApiModelProperty(value = "이미지 파일 생성 경로")
+    private List<String> imageUrl = new ArrayList<>();
 
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/entity/AssetGoal.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/entity/AssetGoal.java
@@ -1,0 +1,49 @@
+package com.backend.moamoa.domain.asset.entity;
+
+import com.backend.moamoa.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.time.LocalDate;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class AssetGoal {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "asset_goal_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public AssetGoal(String content, User user, LocalDate date) {
+        this.content = content;
+        this.user = user;
+        this.date = date;
+    }
+
+    public static AssetGoal createAssetGoal(String content, User user, LocalDate date) {
+        return new AssetGoal(content, user, date);
+    }
+
+    public void updateAssetGoal(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/backend/moamoa/domain/asset/entity/MoneyLog.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/entity/MoneyLog.java
@@ -1,0 +1,70 @@
+package com.backend.moamoa.domain.asset.entity;
+
+import com.backend.moamoa.domain.post.entity.PostImage;
+import com.backend.moamoa.domain.user.entity.User;
+import com.backend.moamoa.global.audit.AuditListener;
+import com.backend.moamoa.global.audit.Auditable;
+import com.backend.moamoa.global.audit.TimeEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static javax.persistence.FetchType.*;
+import static javax.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@EntityListeners(AuditListener.class)
+public class MoneyLog implements Auditable {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "money_log_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private String content;
+
+    @OneToMany(mappedBy = "moneyLog", orphanRemoval = true)
+    private List<PostImage> postImages = new ArrayList<>();
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Embedded
+    private TimeEntity timeEntity;
+
+    @Override
+    public void setTimeEntity(TimeEntity timeEntity) {
+        this.timeEntity = timeEntity;
+    }
+
+    @Builder
+    public MoneyLog(LocalDate date, String content, List<PostImage> postImages, User user) {
+        this.date = date;
+        this.content = content;
+        this.postImages = postImages;
+        this.user = user;
+    }
+
+    public static MoneyLog createMoneyLog(LocalDate date, String content, User user) {
+        return MoneyLog.builder()
+                .date(date)
+                .content(content)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/AssetGoalRepository.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/AssetGoalRepository.java
@@ -1,0 +1,12 @@
+package com.backend.moamoa.domain.asset.repository;
+
+import com.backend.moamoa.domain.asset.entity.AssetGoal;
+import com.backend.moamoa.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface AssetGoalRepository extends JpaRepository<AssetGoal, Long> {
+    Optional<AssetGoal> findByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/backend/moamoa/domain/asset/repository/MoneyLogRepository.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/repository/MoneyLogRepository.java
@@ -1,0 +1,7 @@
+package com.backend.moamoa.domain.asset.repository;
+
+import com.backend.moamoa.domain.asset.entity.MoneyLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MoneyLogRepository extends JpaRepository<MoneyLog, Long> {
+}

--- a/src/main/java/com/backend/moamoa/domain/asset/service/AssetService.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/service/AssetService.java
@@ -1,24 +1,33 @@
 package com.backend.moamoa.domain.asset.service;
 
 import com.backend.moamoa.domain.asset.dto.request.*;
+import com.backend.moamoa.domain.asset.dto.response.CreateMoneyLogResponse;
 import com.backend.moamoa.domain.asset.dto.response.RevenueExpenditureResponse;
 import com.backend.moamoa.domain.asset.dto.response.RevenueExpenditureSumResponse;
 import com.backend.moamoa.domain.asset.entity.*;
 import com.backend.moamoa.domain.asset.repository.*;
+import com.backend.moamoa.domain.post.dto.request.PostRequest;
+import com.backend.moamoa.domain.post.entity.Post;
+import com.backend.moamoa.domain.post.entity.PostImage;
+import com.backend.moamoa.domain.post.repository.post.PostImageRepository;
 import com.backend.moamoa.domain.user.entity.User;
 import com.backend.moamoa.global.exception.CustomException;
 import com.backend.moamoa.global.exception.ErrorCode;
+import com.backend.moamoa.global.s3.S3Uploader;
 import com.backend.moamoa.global.utils.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +42,9 @@ public class AssetService {
     private final ExpenditureRatioRepository expenditureRatioRepository;
     private final RevenueExpenditureRepository revenueExpenditureRepository;
     private final AssetGoalRepository assetGoalRepository;
+    private final PostImageRepository postImageRepository;
+    private final MoneyLogRepository moneyLogRepository;
+    private final S3Uploader s3Uploader;
     private final UserUtil userUtil;
 
     @Transactional
@@ -131,5 +143,30 @@ public class AssetService {
                 .orElseGet(() -> assetGoalRepository.save(AssetGoal.createAssetGoal(request.getContent(), user, request.getDate())));
         assetGoal.updateAssetGoal(request.getContent());
         return assetGoal.getId();
+    }
+
+    @Transactional
+    public CreateMoneyLogResponse createMoneyLog(CreateMoneyLogRequest request) {
+        User user = userUtil.findCurrentUser();
+        MoneyLog moneyLog = moneyLogRepository.save(MoneyLog.createMoneyLog(request.getDate(), request.getContent(), user));
+        List<String> imageUrl = uploadMoneyLogImages(request.getImageFiles(), moneyLog);
+
+        return new CreateMoneyLogResponse(moneyLog.getId(), imageUrl);
+    }
+
+    private List<String> uploadMoneyLogImages(List<MultipartFile> images, MoneyLog moneyLog) {
+        return  images.stream()
+                .map(image -> s3Uploader.upload(image, "moneyLog"))
+                .map(url -> createPostImage(moneyLog, url))
+                .map(PostImage::getImageUrl)
+                .collect(Collectors.toList());
+    }
+
+    private PostImage createPostImage(MoneyLog moneyLog, String url) {
+        return postImageRepository.save(PostImage.builder()
+                .imageUrl(url)
+                .storeFilename(StringUtils.getFilename(url))
+                .moneyLog(moneyLog)
+                .build());
     }
 }

--- a/src/main/java/com/backend/moamoa/domain/asset/service/AssetService.java
+++ b/src/main/java/com/backend/moamoa/domain/asset/service/AssetService.java
@@ -1,19 +1,10 @@
 package com.backend.moamoa.domain.asset.service;
 
-import com.backend.moamoa.domain.asset.dto.request.AssetCategoryRequest;
-import com.backend.moamoa.domain.asset.dto.request.BudgetRequest;
-import com.backend.moamoa.domain.asset.dto.request.CreateRevenueExpenditureRequest;
-import com.backend.moamoa.domain.asset.dto.request.ExpenditureRequest;
+import com.backend.moamoa.domain.asset.dto.request.*;
 import com.backend.moamoa.domain.asset.dto.response.RevenueExpenditureResponse;
 import com.backend.moamoa.domain.asset.dto.response.RevenueExpenditureSumResponse;
-import com.backend.moamoa.domain.asset.entity.AssetCategory;
-import com.backend.moamoa.domain.asset.entity.Budget;
-import com.backend.moamoa.domain.asset.entity.ExpenditureRatio;
-import com.backend.moamoa.domain.asset.entity.RevenueExpenditure;
-import com.backend.moamoa.domain.asset.repository.AssetCategoryRepository;
-import com.backend.moamoa.domain.asset.repository.BudgetRepository;
-import com.backend.moamoa.domain.asset.repository.ExpenditureRatioRepository;
-import com.backend.moamoa.domain.asset.repository.RevenueExpenditureRepository;
+import com.backend.moamoa.domain.asset.entity.*;
+import com.backend.moamoa.domain.asset.repository.*;
 import com.backend.moamoa.domain.user.entity.User;
 import com.backend.moamoa.global.exception.CustomException;
 import com.backend.moamoa.global.exception.ErrorCode;
@@ -41,6 +32,7 @@ public class AssetService {
     private final BudgetRepository budgetRepository;
     private final ExpenditureRatioRepository expenditureRatioRepository;
     private final RevenueExpenditureRepository revenueExpenditureRepository;
+    private final AssetGoalRepository assetGoalRepository;
     private final UserUtil userUtil;
 
     @Transactional
@@ -130,5 +122,14 @@ public class AssetService {
                     .filter(r -> r.getRevenueExpenditureType().toString().equals(type))
                     .mapToInt(RevenueExpenditure::getCost)
                     .sum();
+    }
+
+    @Transactional
+    public Long addAssetGoal(CreateAssetGoalRequest request) {
+        User user = userUtil.findCurrentUser();
+        AssetGoal assetGoal = assetGoalRepository.findByUserAndDate(user, request.getDate())
+                .orElseGet(() -> assetGoalRepository.save(AssetGoal.createAssetGoal(request.getContent(), user, request.getDate())));
+        assetGoal.updateAssetGoal(request.getContent());
+        return assetGoal.getId();
     }
 }

--- a/src/main/java/com/backend/moamoa/domain/post/entity/PostImage.java
+++ b/src/main/java/com/backend/moamoa/domain/post/entity/PostImage.java
@@ -1,5 +1,6 @@
 package com.backend.moamoa.domain.post.entity;
 
+import com.backend.moamoa.domain.asset.entity.MoneyLog;
 import com.backend.moamoa.global.audit.AuditListener;
 import com.backend.moamoa.global.audit.Auditable;
 import com.backend.moamoa.global.audit.TimeEntity;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.*;
 import static javax.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -30,15 +32,20 @@ public class PostImage implements Auditable {
     @Embedded
     private TimeEntity timeEntity;
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
 
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "money_log_id")
+    private MoneyLog moneyLog;
+
     @Builder
-    public PostImage(String imageUrl, String storeFilename, Post post) {
+    public PostImage(String imageUrl, String storeFilename, Post post, MoneyLog moneyLog) {
         this.imageUrl = imageUrl;
         this.storeFilename = storeFilename;
         this.post = post;
+        this.moneyLog = moneyLog;
     }
 
     @Override

--- a/src/main/java/com/backend/moamoa/global/exception/ErrorCode.java
+++ b/src/main/java/com/backend/moamoa/global/exception/ErrorCode.java
@@ -30,7 +30,7 @@ public enum ErrorCode {
 
     INVALID_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "유효하지 않은 리프레쉬 토큰입니다."),
 
-    BAD_REQUEST_EXPENDITURE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 100퍼센트를 맞춰주세요."),
+    BAD_REQUEST_EXPENDITURE(HttpStatus.BAD_REQUEST, "잘못된 요청입니다. 100%를 맞춰주세요."),
 
     ALREADY_NICKNAME_EXISTS(HttpStatus.ALREADY_REPORTED, "이미 존재하는 닉네임입니다."),
 


### PR DESCRIPTION
## 기능 추가 🎉 
- 테이블 2개 추가 `(AssetGoal, Moneylog)`
- 자산 관리 목표, 머니 로그 작성 API 
- 이미지 경로를 저장하는 테이블은 `PostImage` 테이블을 사용했습니다~
- 추가한 API는 아직 리팩토링을 더 해야하고 테이블 구조를 먼저 보여드리려고 올려요!