### PR TITLE
[Refactor] 결산 API 년 자세한 출력 수정

### DIFF
--- a/src/main/java/com/backend/moamoa/domain/settlement/service/SettlementService.java
+++ b/src/main/java/com/backend/moamoa/domain/settlement/service/SettlementService.java
@@ -177,10 +177,8 @@ public class SettlementService {
 
         Boolean fixedExceed = null, variableExceed = null;
 
-        if (type.equals("month")) {
-            fixedExceed = (totalFixedPercent > expenditureRatio.getFixed());
-            variableExceed = (totalVariablePercent > expenditureRatio.getVariable());
-        }
+        fixedExceed = (totalFixedPercent > expenditureRatio.getFixed());
+        variableExceed = (totalVariablePercent > expenditureRatio.getVariable());
 
         List<CostResponse> fixedRes = new ArrayList<>();
         List<CostResponse> costRes = new ArrayList<>();


### PR DESCRIPTION
1. 결산 API에서 년 자세한 출력 API 사용시, 고정비, 변동비 초과 비율이 null이 안되도록 수정했습니다.